### PR TITLE
Card ids

### DIFF
--- a/hanabi_lib/canonical_encoders.cc
+++ b/hanabi_lib/canonical_encoders.cc
@@ -671,6 +671,7 @@ CanonicalObservationEncoder::EncodePrivateV0Belief(
       &encoding,
       &cardCount,
       false);
+  (void)codeLen;
   assert(codeLen == (int)encoding.size());
   std::vector<float> privateV0(encoding.begin(), encoding.begin() + myBeliefSize);
   return {privateV0, cardCount};
@@ -719,6 +720,7 @@ std::vector<float> CanonicalObservationEncoder::EncodeOwnHandTrinary(
   std::vector<float> encoding(len, 0);
   int bits_per_card = 3; // BitsPerCard(game);
   int num_ranks = parent_game_->NumRanks();
+  (void)num_ranks;
 
   int offset = 0;
   const std::vector<HanabiHand>& hands = obs.Hands();

--- a/hanabi_lib/hanabi_card.cc
+++ b/hanabi_lib/hanabi_card.cc
@@ -18,15 +18,22 @@
 
 namespace hanabi_learning_env {
 
-bool HanabiCard::operator==(const HanabiCard& other_card) const {
+bool HanabiCardValue::operator==(const HanabiCardValue& other_card) const {
   return other_card.Color() == Color() && other_card.Rank() == Rank();
 }
 
-std::string HanabiCard::ToString() const {
+std::string HanabiCardValue::ToString() const {
   if (!IsValid()) {
     return std::string("XX");
   }
   return std::string() + ColorIndexToChar(Color()) + RankIndexToChar(Rank());
+}
+
+std::string HanabiCard::ToString() const {
+  if (!IsValid()) {
+    return std::string("XXX");
+  }
+  return std::to_string(Id()) + ColorIndexToChar(Color()) + RankIndexToChar(Rank());
 }
 
 }  // namespace hanabi_learning_env

--- a/hanabi_lib/hanabi_card.h
+++ b/hanabi_lib/hanabi_card.h
@@ -19,11 +19,11 @@
 
 namespace hanabi_learning_env {
 
-class HanabiCard {
+class HanabiCardValue {
  public:
-  HanabiCard(int color, int rank) : color_(color), rank_(rank) {}
-  HanabiCard() = default;  // Create an invalid card.
-  bool operator==(const HanabiCard& other_card) const;
+  HanabiCardValue(int color, int rank) : color_(color), rank_(rank) {}
+  HanabiCardValue() = default;  // Create an invalid card.
+  bool operator==(const HanabiCardValue& other_card) const;
   bool IsValid() const { return color_ >= 0 && rank_ >= 0; }
   std::string ToString() const;
   int Color() const { return color_; }
@@ -32,6 +32,27 @@ class HanabiCard {
  private:
   int color_ = -1;  // 0 indexed card color.
   int rank_ = -1;   // 0 indexed card rank.
+};
+
+class HanabiCard {
+ public:
+  HanabiCard(int color, int rank, int id) : color_(color), rank_(rank), id_(id) {}
+  HanabiCard(HanabiCardValue value, int id) : color_(value.Color()), rank_(value.Rank()), id_(id) {}
+  HanabiCard(int id) : color_(-1), rank_(-1), id_(id) {}
+  HanabiCard() = default;  // Create an invalid card.
+  bool operator==(const HanabiCard& other_card) const = delete;
+  bool IsValid() const { return color_ >= 0 && rank_ >= 0; }
+  std::string ToString() const;
+  int Color() const { return color_; }
+  int Rank() const { return rank_; }
+  HanabiCardValue Value() const { return HanabiCardValue(color_, rank_); }
+  int Id() const { return id_; }
+  HanabiCard HideValue() const { return HanabiCard(-1, -1, id_); }
+
+ private:
+  int color_ = -1;  // 0 indexed card color.
+  int rank_ = -1;   // 0 indexed card rank.
+  int id_ = -1; //Index 0 to N-1 where N is the number of cards in the deck
 };
 
 }  // namespace hanabi_learning_env

--- a/hanabi_lib/hanabi_hand.cc
+++ b/hanabi_lib/hanabi_hand.cc
@@ -69,6 +69,8 @@ HanabiHand::HanabiHand(const HanabiHand& hand, bool hide_cards,
                        bool hide_knowledge) {
   if (hide_cards) {
     cards_.resize(hand.cards_.size(), HanabiCard());
+    for (size_t i = 0; i < hand.cards_.size(); ++i)
+      cards_[i] = hand.cards_[i].HideValue();
   } else {
     cards_ = hand.cards_;
   }

--- a/hanabi_lib/hanabi_hand.h
+++ b/hanabi_lib/hanabi_hand.h
@@ -107,6 +107,14 @@ class HanabiHand {
     return card_knowledge_;
   }
 
+  const std::vector<HanabiCardValue> CardValues() const {
+    std::vector<HanabiCardValue> ret(cards_.size());
+    for (size_t i = 0; i < cards_.size(); ++i) {
+      ret[i] = cards_[i].Value();
+    }
+    return ret;
+  }
+
   std::vector<CardKnowledge>& Knowledge_() {
     return card_knowledge_;
   }
@@ -129,6 +137,27 @@ class HanabiHand {
   void SetCards(const std::vector<HanabiCard>& cards) {
     assert(CanSetCards(cards));
     cards_ = cards;
+  }
+
+  bool CanSetCards(const std::vector<HanabiCardValue>& cards) const {
+    if (cards_.size() != cards.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < cards.size(); ++i) {
+      const auto& card = cards[i];
+      const auto& knowledge = card_knowledge_[i];
+      if (!knowledge.IsCardPlausible(card.Color(), card.Rank())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void SetCards(const std::vector<HanabiCardValue>& cards) {
+    assert(CanSetCards(cards));
+    for (size_t i = 0; i < cards.size(); ++i)
+      cards_[i] = HanabiCard(cards[i],cards_[i].Id());
   }
 
   void AddCard(HanabiCard card, const CardKnowledge& initial_knowledge);

--- a/hanabi_lib/hanabi_state.cc
+++ b/hanabi_lib/hanabi_state.cc
@@ -75,7 +75,7 @@ HanabiCard HanabiState::HanabiDeck::DealCard(std::mt19937* rng) {
   --card_count_[index];
   --total_count_;
   deck_history_.push_back(index);
-  return HanabiCard(IndexToColor(index), IndexToRank(index));
+  return HanabiCard(IndexToColor(index), IndexToRank(index), total_count_);
 }
 
 HanabiCard HanabiState::HanabiDeck::DealCard(int color, int rank) {
@@ -87,7 +87,7 @@ HanabiCard HanabiState::HanabiDeck::DealCard(int color, int rank) {
   --card_count_[index];
   --total_count_;
   deck_history_.push_back(index);
-  return HanabiCard(IndexToColor(index), IndexToRank(index));
+  return HanabiCard(IndexToColor(index), IndexToRank(index), total_count_);
 }
 
 HanabiState::HanabiState(const HanabiGame* parent_game, int start_player)

--- a/hanabi_lib/hanabi_state.cc
+++ b/hanabi_lib/hanabi_state.cc
@@ -239,6 +239,7 @@ void HanabiState::ApplyMove(HanabiMove move) {
         }
         if (!deck_order_.empty()) {
           auto card = deck_order_.back();
+          (void)card;
           assert(move.Color() == card.Color() && move.Rank() == card.Rank());
           deck_order_.pop_back();
         }

--- a/hanabi_lib/hanabi_state.h
+++ b/hanabi_lib/hanabi_state.h
@@ -61,6 +61,13 @@ class HanabiState {
       }
     }
 
+    void DealCards(const std::vector<HanabiCardValue>& cards) {
+      intervened_ = true;
+      for (const auto& card : cards) {
+        DealCard(card.Color(), card.Rank());
+      }
+    }
+
     void DealCards(const std::vector<HanabiCard>& cards) {
       intervened_ = true;
       for (const auto& card : cards) {

--- a/hanabi_lib/hanabi_state.h
+++ b/hanabi_lib/hanabi_state.h
@@ -178,9 +178,10 @@ class HanabiState {
     parent_game_ = game;
   }
 
-  void SetDeckOrder(const std::vector<HanabiCard>& cards) {
+  void SetDeckOrder(const std::vector<HanabiCardValue>& cards) {
     assert(deck_order_.empty());
-    deck_order_ = cards;
+    for (size_t i = 0; i < cards.size(); ++i)
+      deck_order_.push_back(HanabiCard(cards[i],(int)i));
   }
 
  private:


### PR DESCRIPTION
This PR renames HanabiCard -> HanabiCardValue and then adds an "id" field to the old HanabiCard that ranges from 0 to decksize-1, which can be used as a key to track exact cards.

For safety, we also disable operator== on HanabiCard, to make sure there aren't any subtle uses by anyone that were relying on its semantics, now that there is a new field in the card.

While writing this PR, I also temporarily made HanabiCard have no default constructor either and then compiled, to find all call sites that would be creating a HanabiCard and silently putting in a bad id in situations where we need to have an id but don't want the card value to be visible.
